### PR TITLE
Feature/packet input ways

### DIFF
--- a/tracevis.py
+++ b/tracevis.py
@@ -12,6 +12,8 @@ import utils.ripe_atlas
 import utils.trace
 import utils.vis
 
+import textwrap
+
 TIMEOUT = 1
 MAX_TTL = 50
 DEFAULT_OUTPUT_DIR = "./tracevis_data/"
@@ -22,13 +24,20 @@ OS_NAME = platform.system()
 def get_args():
     parser = argparse.ArgumentParser(
         description='Traceroute with any packet. \
-            Visualize the routes. Discover Middleboxes and Firewalls')
+            Visualize the routes. Discover Middleboxes and Firewalls', formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('-n', '--name', action='store',
                         help="prefix for the graph file name")
     parser.add_argument('-i', '--ips', type=str,
                         help="add comma-separated IPs (up to 6 for two packet and up to 12 for one packet)")
     parser.add_argument('-p', '--packet', action='store_true',
                         help="receive one or two packets from the IP layer via the terminal input and trace route with")
+    parser.add_argument('--packet-input-method', dest='packet_input_method', choices=['stdin','file','hex','interactive'], default="hex",
+                        help=textwrap.dedent("""Select packet input method 
+stdin: read packet from stdin (pipe)
+file: read packet from a file (set via --packet-file)
+hex: paste hex dump of packet into interactive shell 
+interactive: use full featured scapy and python console to craft packet\n\n"""))
+    parser.add_argument("--packet-file", dest='packet_file', type=str, help="Packet file path if input method is 'file'")
     parser.add_argument('--dns', action='store_true',
                         help="trace route with a simple DNS over UDP packet")
     parser.add_argument('--dnstcp', action='store_true',

--- a/tracevis.py
+++ b/tracevis.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import argparse
-import os
+import os, sys
 import platform
 
 import utils.csv
@@ -14,6 +14,10 @@ import utils.vis
 
 import textwrap
 
+import json
+from copy import deepcopy
+
+
 TIMEOUT = 1
 MAX_TTL = 50
 REPEAT_REQUESTS = 3
@@ -22,22 +26,31 @@ DEFAULT_REQUEST_IPS = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
 OS_NAME = platform.system()
 
 
+def dump_non_default_args_to_file(file, args):
+    args_without_config_arg = args.copy()
+    if 'config_file' in args_without_config_arg:
+        del args_without_config_arg['config_file']
+    with open(file,'w') as f:
+        json.dump(args_without_config_arg, f, indent=4, sort_keys=True)
+
 def get_args():
     parser = argparse.ArgumentParser(
         description='Traceroute with any packet. \
             Visualize the routes. Discover Middleboxes and Firewalls', formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('--config-file', type=str, default=None,
+                        help='Load configuration from file'),
     parser.add_argument('-n', '--name', action='store',
                         help="prefix for the graph file name")
     parser.add_argument('-i', '--ips', type=str,
                         help="add comma-separated IPs (up to 6 for two packet and up to 12 for one packet)")
     parser.add_argument('-p', '--packet', action='store_true',
                         help="receive one or two packets from the IP layer via the terminal input and trace route with")
-    parser.add_argument('--packet-input-method', dest='packet_input_method', choices=['file','hex','interactive'], default="hex",
+    parser.add_argument('--packet-input-method', dest='packet_input_method', choices=['json','hex','interactive'], default="hex",
                         help=textwrap.dedent("""Select packet input method 
-- file: read packet from a file (set via --packet-file)
+- json: load packet data from a json/file(set via --packet-data)
 - hex: paste hex dump of packet into interactive shell 
 - interactive: use full featured scapy and python console to craft packet\n\n"""))
-    parser.add_argument("--packet-file", dest='packet_file', type=str, help="Packet file path if input method is 'file'", default=None)
+    parser.add_argument("--packet-data", dest='packet_data', type=str, help="Packet json data if input method is 'json' (use @file to load from file)", default=None)
     parser.add_argument('--dns', action='store_true',
                         help="trace route with a simple DNS over UDP packet")
     parser.add_argument('--dnstcp', action='store_true',
@@ -80,14 +93,30 @@ def get_args():
 - 'new' : to change source port, sequence number, etc in each request (default)
 - 'new,rexmit' : to begin with the 'new' option in each of the three steps for all destinations and then rexmit"""
                         )
+    
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
 
     args = parser.parse_args()
+    if args.config_file:
+        with open(args.config_file) as f:
+            return json.load(f)
+    
     if args.packet_input_method == 'file' and args.packet_file is None:
         parser.error("--packet-input-method requires --packet-file.")
-    return args
+
+    return vars(args)
 
 
 def main(args):
+    if args.get('packet_data') and isinstance(args.get('packet_data'), str):
+        if args.get('packet_data')[0] == '@':
+            with open(args.get('packet_data')[1:]) as f:
+                args['packet_data'] = json.load(f)
+        else:
+            args['packet_data'] = json.loads(args.get('packet_data'))
+
     name_prefix = ""
     continue_to_max_ttl = False
     max_ttl = MAX_TTL
@@ -159,8 +188,9 @@ def main(args):
         name_prefix += "packet"
         try:
             
-            if args.get('packet_input_method') == 'file':
-                input_packet = utils.packet_input.InputPacketInfo.from_config_file(OS_NAME, trace_retransmission, file=args.get('packet_file'))
+            if args.get('packet_input_method') == 'json':
+                input_packet = utils.packet_input.InputPacketInfo.from_json(OS_NAME, trace_retransmission, 
+                                                                            packet_data=deepcopy(args.get('packet_data')))
             elif args.get('packet_input_method') == 'interactive':
                 input_packet = utils.packet_input.InputPacketInfo.from_scapy(OS_NAME, trace_retransmission)
             elif args.get('packet_input_method') == 'hex':
@@ -181,7 +211,6 @@ def main(args):
     if do_traceroute:
         if args.get("packet") or args.get("rexmit"):
             with input_packet as ctx:
-                print(ctx)
                 packet_1, packet_2, do_tcph1, do_tcph2 = ctx
                 was_successful, measurement_path = utils.trace.trace_route(
                     ip_list=request_ips, request_packet_1=packet_1, output_dir=output_dir,
@@ -219,6 +248,9 @@ def main(args):
         else:
             was_successful = True
     if was_successful:
+        config_dump_file_name = f"{os.path.splitext(measurement_path)[0]}.conf"
+        dump_non_default_args_to_file(config_dump_file_name, args)
+        
         if utils.vis.vis(
                 measurement_path=measurement_path, attach_jscss=attach_jscss,
                 edge_lable=edge_lable):
@@ -226,4 +258,4 @@ def main(args):
 
 
 if __name__ == "__main__":
-    main(vars(get_args()))
+    main(get_args())

--- a/utils/packet_input.py
+++ b/utils/packet_input.py
@@ -165,7 +165,7 @@ class InputPacketInfo:
         return packet
         
     @classmethod
-    def from_config_file(cls, os_name: str, trace_retransmission: bool, file: str):
+    def from_json(cls, os_name: str, trace_retransmission: bool, packet_data: json):
         copy_packet_1 :'scapy.layers.inet.Packet' = None
         copy_packet_2 :'scapy.layers.inet.Packet' = None
         do_tcph1 :bool = False
@@ -173,8 +173,7 @@ class InputPacketInfo:
         add_firewall_rule = False
 
         try:
-            with open(file) as f:
-                json_config = json.load(f) 
+            json_config = packet_data
             copy_packet_1 = cls._read_json_packet(json_config, 'packet1', show=True)
             if not trace_retransmission:
                 if copy_packet_1.haslayer(TCP):

--- a/utils/packet_input.py
+++ b/utils/packet_input.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
+from struct import pack
 from scapy.layers.inet import IP, TCP
 from scapy.utils import import_hexcap
+import json 
 
 firewall_commands_help = "\r\n( · - · · · \r\n\
 You may need to temporarily block RST output packets in your firewall.\r\n\
@@ -9,7 +11,8 @@ iptables -A OUTPUT -p tcp --tcp-flags RST RST -j DROP\r\n\
 After the test, you can delete it:\r\n\
 iptables -D OUTPUT -p tcp --tcp-flags RST RST -j DROP\r\n · - · - · )\r\n\
     "
-
+class BADPacket(Exception):
+    ...
 
 def yesno_second_packet(question):
     prompt = f'{question} (y/n): '
@@ -24,6 +27,7 @@ def yesno_second_packet(question):
 
 def supported_or_correct(copied_packet):
     return (copied_packet[IP].version == 4)
+
 
 
 def copy_input_packets(os_name: str, trace_retransmission: bool):
@@ -80,3 +84,124 @@ def copy_input_packets(os_name: str, trace_retransmission: bool):
     print(
         " ********************************************************************** ")
     return copy_packet_1, copy_packet_2, do_tcph1, do_tcph2
+
+
+def read_input_packets(os_name: str, trace_retransmission: bool, file: str):
+    copy_packet_1 = ""
+    copy_packet_2 = ""
+    do_tcph1 = False
+    do_tcph2 = False
+    try:
+        with open(file) as f:
+            json_config = json.load(f) 
+        copy_packet_1 = IP(import_hexcap(json_config['packet1']['hex']))
+        print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+        print(" . . . - . developed view of first packet:")
+        copy_packet_1.show()
+        print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+        # todo xhdix: we should have better solution
+        if not supported_or_correct(copy_packet_1):
+            print(" · · · · · · · · it's not IPv4 or the hexdump is not started with IP layer")
+            print(
+                " · · · · · · · · please check the packet and try again. ( •_•)>⌐■-■ exiting.. ")
+            print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+        if not trace_retransmission:
+            if copy_packet_1.haslayer(TCP):
+                if copy_packet_1[TCP].flags == "PA":
+                    do_tcph1 = json_config['packet1'].get('handshake', False)
+            if 'packet2' in json_config:
+                copy_packet_2 = IP(import_hexcap(json_config['packet2']['hex']))
+                print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+                print(" . . . - . developed view of this packet:")
+                copy_packet_2.show()
+                print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+                if not supported_or_correct(copy_packet_1):
+                    print(
+                        " · · · · · · · · it's not IPv4 or the hexdump is not started with IP layer")
+                    print(
+                        " · · · · · · · · please check the packet and try again. ( •_•)>⌐■-■ exiting.. ")
+                    print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+                if copy_packet_2.haslayer(TCP):
+                    if copy_packet_2[TCP].flags == "PA":
+                        do_tcph2 = json_config['packet2'].get('handshake', False)
+        print(
+            " ********************************************************************** ")
+    except FileNotFoundError:
+        print(f" · · · · · · · · file '{file}' not found!.")
+        raise BADPacket("File Not Found")
+    return copy_packet_1, copy_packet_2, do_tcph1, do_tcph2
+
+
+def read_input_packets_scapy(os_name: str, trace_retransmission: bool):
+    from scapy.layers.inet import IP, TCP
+    from scapy.utils import import_hexcap
+
+    copy_packet_1 = ""
+    copy_packet_2 = ""
+    do_tcph1 = False
+    do_tcph2 = False
+    banner = "Please create your packet in variable \"p\" and exit when you are done"
+    try:
+        from IPython.terminal.embed import InteractiveShellEmbed
+        ipshell = InteractiveShellEmbed(banner1=banner, user_ns=locals())
+        ipshell()
+        copy_packet_1 = ipshell.user_ns['p']
+    except:
+        # FIXME: Make this work with default console 
+        raise NotImplementedError("Currently Only IPython Console is supported!")
+        import code
+        code.interact(banner=banner, local=locals())
+        copy_packet_1 = p 
+    print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+    print(" . . . - . developed view of first packet:")
+    copy_packet_1.show()
+    print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+    # todo xhdix: we should have better solution
+    if not supported_or_correct(copy_packet_1):
+        print(" · · · · · · · · it's not IPv4 or the hexdump is not started with IP layer")
+        print(
+            " · · · · · · · · please check the packet and try again. ( •_•)>⌐■-■ exiting.. ")
+        print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+        raise BADPacket("Invalid Packet!")
+    if not trace_retransmission:
+        if copy_packet_1.haslayer(TCP):
+            if copy_packet_1[TCP].flags == "PA":
+                if os_name == "Linux":
+                    do_tcph1 = yesno_second_packet(
+                        "Would you like to do a TCP Handshake before sending this packet?"
+                        + firewall_commands_help)
+                else:
+                    do_tcph1 = yesno_second_packet(
+                        "Would you like to do a TCP Handshake before sending this packet?")
+        if yesno_second_packet("Would you like to add a second packet"):
+            banner = "Please create your packet in variable \"p\" and exit when you are done"
+            try:
+                from IPython.terminal.embed import InteractiveShellEmbed
+                ipshell = InteractiveShellEmbed(banner1=banner, user_ns=locals())
+                ipshell()
+                copy_packet_2 = ipshell.user_ns['p']
+            except:
+                # FIXME: Make this work with default console 
+                raise NotImplementedError("Currently Only IPython Console is supported!")
+                import code
+                code.interact(banner=banner, local=locals())
+                copy_packet_2 = p
+            print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+            print(" . . . - . developed view of this packet:")
+            copy_packet_2.show()
+            print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+            if not supported_or_correct(copy_packet_1):
+                print(
+                    " · · · · · · · · it's not IPv4 or the hexdump is not started with IP layer")
+                print(
+                    " · · · · · · · · please check the packet and try again. ( •_•)>⌐■-■ exiting.. ")
+                print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+                raise BADPacket("Invalid Packet!")
+            if copy_packet_2.haslayer(TCP):
+                if copy_packet_2[TCP].flags == "PA":
+                    do_tcph2 = yesno_second_packet(
+                        "Would you like to do a TCP Handshake before sending this packet?")
+    print(
+        " ********************************************************************** ")
+    return copy_packet_1, copy_packet_2, do_tcph1, do_tcph2
+

--- a/utils/packet_input.py
+++ b/utils/packet_input.py
@@ -1,207 +1,249 @@
 #!/usr/bin/env python3
-from struct import pack
 from scapy.layers.inet import IP, TCP
 from scapy.utils import import_hexcap
+import subprocess
+import base64
 import json 
 
-firewall_commands_help = "\r\n( · - · · · \r\n\
+
+FIREWALL_COMMANDS_HELP = "\r\n( · - · · · \r\n\
 You may need to temporarily block RST output packets in your firewall.\r\n\
 For example:\r\n\
 iptables -A OUTPUT -p tcp --tcp-flags RST RST -j DROP\r\n\
 After the test, you can delete it:\r\n\
-iptables -D OUTPUT -p tcp --tcp-flags RST RST -j DROP\r\n · - · - · )\r\n\
-    "
-class BADPacket(Exception):
+iptables -D OUTPUT -p tcp --tcp-flags RST RST -j DROP\r\n · - · - · )\r\n" 
+
+
+class BADPacketException(Exception):
+    """ An Exception which is thrown on bad packets """
     ...
 
-def yesno_second_packet(question):
-    prompt = f'{question} (y/n): '
-    answer = input(prompt).strip().lower()
-    if answer not in ['y', 'n']:
-        print(f'{answer} is invalid, please try again...')
-        return yesno_second_packet(question)
-    if answer == 'y':
-        return True
-    return False
+class FirewallException(Exception):
+    """ An Exception which is thrown on firewall errors """
+    ...
 
 
-def supported_or_correct(copied_packet):
-    return (copied_packet[IP].version == 4)
+class InputPacketInfo:
+    def __init__(self, packet1, packet2, do_tcph1, do_tcph2, add_firewall_rule):
+        self._packet1 = packet1
+        self._packet2 = packet2
+        self._do_tcph1 = do_tcph1
+        self._do_tcph2 = do_tcph2
+        self._add_firewall_rule = add_firewall_rule
+
+    @property
+    def params(self):
+         return (self._packet1 or "", self._packet2 or "", self._do_tcph1, self._do_tcph2)
+
+    def __enter__(self):
+        if self._add_firewall_rule:
+            self._add_firewal_out_drop_rule()
+        return self.params 
+
+    def __exit__(self, *args, **kwargs):
+        if self._add_firewall_rule:
+            self._remove_firewal_out_drop_rule()
+
+    @classmethod
+    def _iptables_exists(cls):
+        try:
+            p = subprocess.run([ 'iptables', '-L', '-n'], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+    @classmethod
+    def _check_firewal_out_drop_rule(cls):
+        try:
+            p = subprocess.run([ 'iptables', '-C', 'OUTPUT', '-p', 'tcp', 
+                                '--tcp-flags', 'RST', 'RST', '-j', 'DROP'], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+    @classmethod
+    def _add_firewal_out_drop_rule(cls):
+        try:
+            p = subprocess.run([ 'iptables', '-A', 'OUTPUT', '-p', 'tcp', 
+                                '--tcp-flags', 'RST', 'RST', '-j', 'DROP'], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            if not cls._check_firewal_out_drop_rule():
+                raise FirewallException("Added DROP rule cannot be verified")
+            return True
+        except subprocess.CalledProcessError:
+            raise FirewallException("Adding DROP rule failed")
+            
+    @classmethod
+    def _remove_firewal_out_drop_rule(cls):
+        try:
+            p = subprocess.run([ 'iptables', '-D', 'OUTPUT', '-p', 'tcp', 
+                                '--tcp-flags', 'RST', 'RST', '-j', 'DROP'], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            if cls._check_firewal_out_drop_rule():
+                raise FirewallException("Removing DROP rule cannot be verified")
+            return True
+        except subprocess.CalledProcessError:
+            raise FirewallException("Removing DROP rule failed")
 
 
+    @classmethod
+    def _ask_yesno(cls, question):
+        prompt = f'{question} (y/n): '
+        answer = input(prompt).strip().lower()
+        if answer not in ['y', 'n']:
+            print(f'{answer} is invalid, please try again...')
+            return cls._ask_yesno(question)
+        if answer == 'y':
+            return True
+        return False
 
-def copy_input_packets(os_name: str, trace_retransmission: bool):
-    copy_packet_1 = ""
-    copy_packet_2 = ""
-    do_tcph1 = False
-    do_tcph2 = False
-    print(
-        " ********************************************************************** ")
-    print(
-        " paste here the first packet hex dump start with the IP layer and then enter :")
-    print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-    copy_packet_1 = IP(import_hexcap())
-    print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-    print(" . . . - . developed view of this packet:")
-    copy_packet_1.show()
-    print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-    # todo xhdix: we should have better solution
-    if not supported_or_correct(copy_packet_1):
-        print(" · · · · · · · · it's not IPv4 or the hexdump is not started with IP layer")
-        print(
-            " · · · · · · · · please check the packet and try again. ( •_•)>⌐■-■ exiting.. ")
+
+    @classmethod
+    def _supported_or_correct(cls, copied_packet):
+        return (copied_packet[IP].version == 4)
+
+
+    @classmethod
+    def _read_pasted_packet(cls, show=False):
+        print(" ********************************************************************** ")
+        print(" paste here the packet hex dump start with the IP layer and then enter :")
         print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-    if not trace_retransmission:
-        if copy_packet_1.haslayer(TCP):
-            if copy_packet_1[TCP].flags == "PA":
-                if os_name == "Linux":
-                    do_tcph1 = yesno_second_packet(
-                        "Would you like to do a TCP Handshake before sending this packet?"
-                        + firewall_commands_help)
-                else:
-                    do_tcph1 = yesno_second_packet(
-                        "Would you like to do a TCP Handshake before sending this packet?")
-                print(" · - · - ·     · - · - ·     · - · - ·     · - · - · ")
-        if yesno_second_packet("Would you like to add a second packet"):
-            print(
-                " paste here the second packet hex dump start with the IP layer and then enter (optional) :")
-            print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-            copy_packet_2 = IP(import_hexcap())
-            print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+        p1 = IP(import_hexcap())
+        print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+        if not  cls._supported_or_correct(p1):
+            raise BADPacketException("it's not IPv4 or the hexdump is not started with IP layer")
+        if show:
             print(" . . . - . developed view of this packet:")
-            copy_packet_2.show()
+            p1.show()
             print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-            if not supported_or_correct(copy_packet_1):
-                print(
-                    " · · · · · · · · it's not IPv4 or the hexdump is not started with IP layer")
-                print(
-                    " · · · · · · · · please check the packet and try again. ( •_•)>⌐■-■ exiting.. ")
-                print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-            if copy_packet_2.haslayer(TCP):
-                if copy_packet_2[TCP].flags == "PA":
-                    do_tcph2 = yesno_second_packet(
-                        "Would you like to do a TCP Handshake before sending this packet?")
-    print(
-        " ********************************************************************** ")
-    return copy_packet_1, copy_packet_2, do_tcph1, do_tcph2
+        return p1
 
 
-def read_input_packets(os_name: str, trace_retransmission: bool, file: str):
-    copy_packet_1 = ""
-    copy_packet_2 = ""
-    do_tcph1 = False
-    do_tcph2 = False
-    try:
-        with open(file) as f:
-            json_config = json.load(f) 
-        copy_packet_1 = IP(import_hexcap(json_config['packet1']['hex']))
-        print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-        print(" . . . - . developed view of first packet:")
-        copy_packet_1.show()
-        print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-        # todo xhdix: we should have better solution
-        if not supported_or_correct(copy_packet_1):
-            print(" · · · · · · · · it's not IPv4 or the hexdump is not started with IP layer")
-            print(
-                " · · · · · · · · please check the packet and try again. ( •_•)>⌐■-■ exiting.. ")
-            print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+
+    @classmethod
+    def from_stdin(cls, os_name: str, trace_retransmission: bool):
+        copy_packet_1 :'scapy.layers.inet.Packet' = None
+        copy_packet_2 :'scapy.layers.inet.Packet' = None
+        do_tcph1 :bool = False
+        do_tcph2 :bool = False
+        add_firewall_rule = False
+
+        copy_packet_1 = cls._read_pasted_packet(True)
         if not trace_retransmission:
-            if copy_packet_1.haslayer(TCP):
-                if copy_packet_1[TCP].flags == "PA":
-                    do_tcph1 = json_config['packet1'].get('handshake', False)
-            if 'packet2' in json_config:
-                copy_packet_2 = IP(import_hexcap(json_config['packet2']['hex']))
-                print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-                print(" . . . - . developed view of this packet:")
-                copy_packet_2.show()
-                print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-                if not supported_or_correct(copy_packet_1):
-                    print(
-                        " · · · · · · · · it's not IPv4 or the hexdump is not started with IP layer")
-                    print(
-                        " · · · · · · · · please check the packet and try again. ( •_•)>⌐■-■ exiting.. ")
-                    print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+            if copy_packet_1.haslayer(TCP) and copy_packet_1[TCP].flags == "PA":
+                if os_name.lower() == "linux":
+                    if cls._iptables_exists():
+                        do_tcph1 = cls._ask_yesno(f"Would you like to do a TCP Handshake before sending this packet?")
+                        if not cls._check_firewal_out_drop_rule():
+                            add_firewall_rule = cls._ask_yesno(f"{FIREWALL_COMMANDS_HELP}\n\nDo You want add rules automaticallly?")
+                    else:
+                        # FIXME: WHAT IF NOT? FAIL?
+                        raise FirewallException("No iptables!")
+                else:
+                    do_tcph1 = cls._ask_yesno("Would you like to do a TCP Handshake before sending this packet?")
+                print(" · - · - ·     · - · - ·     · - · - ·     · - · - · ")
+
+                    
+            if cls._ask_yesno("Would you like to add a second packet"):
+                copy_packet_2 = cls._read_pasted_packet(True)
                 if copy_packet_2.haslayer(TCP):
                     if copy_packet_2[TCP].flags == "PA":
-                        do_tcph2 = json_config['packet2'].get('handshake', False)
-        print(
-            " ********************************************************************** ")
-    except FileNotFoundError:
-        print(f" · · · · · · · · file '{file}' not found!.")
-        raise BADPacket("File Not Found")
-    return copy_packet_1, copy_packet_2, do_tcph1, do_tcph2
+                        do_tcph2 = cls._ask_yesno("Would you like to do a TCP Handshake before sending this packet?")
+        print(" ********************************************************************** ")
+        return InputPacketInfo(copy_packet_1, copy_packet_2, do_tcph1,  do_tcph2, add_firewall_rule)
 
-
-def read_input_packets_scapy(os_name: str, trace_retransmission: bool):
-    from scapy.layers.inet import IP, TCP
-    from scapy.utils import import_hexcap
-
-    copy_packet_1 = ""
-    copy_packet_2 = ""
-    do_tcph1 = False
-    do_tcph2 = False
-    banner = "Please create your packet in variable \"p\" and exit when you are done"
-    try:
-        from IPython.terminal.embed import InteractiveShellEmbed
-        ipshell = InteractiveShellEmbed(banner1=banner, user_ns=locals())
-        ipshell()
-        copy_packet_1 = ipshell.user_ns['p']
-    except:
-        # FIXME: Make this work with default console 
-        raise NotImplementedError("Currently Only IPython Console is supported!")
-        import code
-        code.interact(banner=banner, local=locals())
-        copy_packet_1 = p 
-    print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-    print(" . . . - . developed view of first packet:")
-    copy_packet_1.show()
-    print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-    # todo xhdix: we should have better solution
-    if not supported_or_correct(copy_packet_1):
-        print(" · · · · · · · · it's not IPv4 or the hexdump is not started with IP layer")
-        print(
-            " · · · · · · · · please check the packet and try again. ( •_•)>⌐■-■ exiting.. ")
+    @classmethod
+    def _read_json_packet(cls, json_config, k, show=False):
+        if json_config[k]['hex'].startswith("b64:"):
+            json_config[k]['hex'] = base64.b64decode(json_config[k]['hex'][4:].strip()).decode()
+        packet = IP(import_hexcap(json_config[k]['hex']))
         print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-        raise BADPacket("Invalid Packet!")
-    if not trace_retransmission:
-        if copy_packet_1.haslayer(TCP):
-            if copy_packet_1[TCP].flags == "PA":
-                if os_name == "Linux":
-                    do_tcph1 = yesno_second_packet(
-                        "Would you like to do a TCP Handshake before sending this packet?"
-                        + firewall_commands_help)
+        print(" . . . - . developed view of first packet:")
+        if not cls._supported_or_correct(packet):
+            BADPacketException(f"{k} it's not IPv4 or the hexdump is not started with IP layer")
+        if show:
+            packet.show()
+            print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+        return packet
+        
+    @classmethod
+    def from_config_file(cls, os_name: str, trace_retransmission: bool, file: str):
+        copy_packet_1 :'scapy.layers.inet.Packet' = None
+        copy_packet_2 :'scapy.layers.inet.Packet' = None
+        do_tcph1 :bool = False
+        do_tcph2 :bool = False
+        add_firewall_rule = False
+
+        try:
+            with open(file) as f:
+                json_config = json.load(f) 
+            copy_packet_1 = cls._read_json_packet(json_config, 'packet1', show=True)
+            if not trace_retransmission:
+                if copy_packet_1.haslayer(TCP):
+                    if copy_packet_1[TCP].flags == "PA":
+                        do_tcph1 = json_config['packet1'].get('handshake', False)
+                if 'packet2' in json_config:
+                    copy_packet_2 = cls._read_json_packet(json_config, 'packet2', show=True)
+                    if copy_packet_2.haslayer(TCP):
+                        if copy_packet_2[TCP].flags == "PA":
+                            do_tcph2 = json_config['packet2'].get('handshake', False)
+            add_firewall_rule = json_config.get('add_firewall_drop', False)            
+            print(" ********************************************************************** ")
+        except FileNotFoundError:
+            print(f" · · · · · · · · file '{file}' not found!.")
+            raise BADPacketException("File Not Found")
+        return InputPacketInfo(copy_packet_1, copy_packet_2, do_tcph1,  do_tcph2, add_firewall_rule)
+
+    @classmethod
+    def _read_interactive_packet(cls, show=False):
+        from scapy.layers.inet import IP, TCP
+        banner = "Please create your packet in variable \"p\" and exit when you are done"
+        try:
+            from IPython.terminal.embed import InteractiveShellEmbed
+            ipshell = InteractiveShellEmbed(banner1=banner, user_ns=locals())
+            ipshell()
+            packet = ipshell.user_ns['p']
+        except:
+            # FIXME: Make this work with default console 
+            raise NotImplementedError("Currently Only IPython Console is supported!")
+            import code
+            code.interact(banner=banner, local=locals())
+            packet = p 
+
+        if not cls._supported_or_correct(packet):
+            raise BADPacketException("it's not IPv4 or the hexdump is not started with IP layer")
+        if show:
+            print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+            print(" . . . - . developed view of first packet:")
+            packet.show()
+            print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+        return packet
+
+    @classmethod
+    def from_scapy(cls, os_name: str, trace_retransmission: bool):
+        copy_packet_1 = ""
+        copy_packet_2 = ""
+        do_tcph1 = False
+        do_tcph2 = False
+        add_firewall_rule = False
+
+
+        copy_packet_1 = cls._read_interactive_packet(show=True)
+        if not trace_retransmission:
+            if os_name.lower() == "linux":
+                if cls._iptables_exists():
+                    do_tcph1 = cls._ask_yesno(f"Would you like to do a TCP Handshake before sending this packet?")
+                    if not cls._check_firewal_out_drop_rule():
+                        add_firewall_rule = cls._ask_yesno(f"{FIREWALL_COMMANDS_HELP}\n\nDo You want add rules automaticallly?")
                 else:
-                    do_tcph1 = yesno_second_packet(
-                        "Would you like to do a TCP Handshake before sending this packet?")
-        if yesno_second_packet("Would you like to add a second packet"):
-            banner = "Please create your packet in variable \"p\" and exit when you are done"
-            try:
-                from IPython.terminal.embed import InteractiveShellEmbed
-                ipshell = InteractiveShellEmbed(banner1=banner, user_ns=locals())
-                ipshell()
-                copy_packet_2 = ipshell.user_ns['p']
-            except:
-                # FIXME: Make this work with default console 
-                raise NotImplementedError("Currently Only IPython Console is supported!")
-                import code
-                code.interact(banner=banner, local=locals())
-                copy_packet_2 = p
-            print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-            print(" . . . - . developed view of this packet:")
-            copy_packet_2.show()
-            print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-            if not supported_or_correct(copy_packet_1):
-                print(
-                    " · · · · · · · · it's not IPv4 or the hexdump is not started with IP layer")
-                print(
-                    " · · · · · · · · please check the packet and try again. ( •_•)>⌐■-■ exiting.. ")
-                print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-                raise BADPacket("Invalid Packet!")
-            if copy_packet_2.haslayer(TCP):
-                if copy_packet_2[TCP].flags == "PA":
-                    do_tcph2 = yesno_second_packet(
-                        "Would you like to do a TCP Handshake before sending this packet?")
-    print(
-        " ********************************************************************** ")
-    return copy_packet_1, copy_packet_2, do_tcph1, do_tcph2
+                    # FIXME: WHAT IF NOT? FAIL?
+                    raise FirewallException("No iptables!")
+            else:
+                do_tcph1 = cls._ask_yesno("Would you like to do a TCP Handshake before sending this packet?")
+            print(" · - · - ·     · - · - ·     · - · - ·     · - · - · ")
+
+            if cls._ask_yesno("Would you like to add a second packet"):
+                copy_packet_2 = cls._read_interactive_packet(show=True)
+                if copy_packet_2.haslayer(TCP) and copy_packet_2[TCP].flags == "PA":
+                    do_tcph2 = cls._ask_yesno("Would you like to do a TCP Handshake before sending this packet?")
+        print(" ********************************************************************** ")
+        return InputPacketInfo(copy_packet_1, copy_packet_2, do_tcph1,  do_tcph2, add_firewall_rule)
 


### PR DESCRIPTION
Multiple packet input method support added: hex (default), file, interactive  
User can select method by setting `--packet-input-method` to `hex`, `file`, `interactive` 
If user select `--packet-input-method file` the `--packet-file` option must also be supplied  

**File Mode**
the `--packet-file` option gets a `JSON` file with this format: 
```
{
  "packet1": {
    "hex": "...",
    "handshake": false
  },
  "packet2": {
    "hex": "...",
    "handshake": true
  }
} 

```
`packet2` key can be committed entirely

**Interactive Mode**  
with `--packet-input-method interactive` an `ipython` console is opened and user can craft his packet there and finally store it into variable `p` 
This feature currently requires `ipython` and doesn't work with default python console. 