### PR TITLE
detect NAT and PEP

### DIFF
--- a/tracevis.py
+++ b/tracevis.py
@@ -66,6 +66,9 @@ def get_args():
                         help="annotation for the second packets (dns and packet trace)")
     parser.add_argument('--rexmit', action='store_true',
                         help="same as rexmit option (only one packet. all TTL steps, same stream)")
+    parser.add_argument('--paris', action='store_true',
+                        help="same as 'new,rexmit' option (like Paris-Traceroute)")
+    # this argument ('-o', '--options') will be changed or removed before v1.0.0
     parser.add_argument('-o', '--options', type=str, default="new",
                         help="change the behavior of the trace route" 
                             + " - 'rexmit' : to be similar to doing retransmission with incremental TTL (only one packet, one destination)"
@@ -128,14 +131,17 @@ def main(args):
         edge_lable = args["label"].lower()
     if args.get("rexmit"):
         trace_retransmission = True
+    if args.get("paris"):
+        trace_with_retransmission = True
     if args.get("options"):
-        trace_options= args["options"].replace(' ', '').split(',')
+        # this argument will be changed or removed before v1.0.0
+        trace_options = args["options"].replace(' ', '').split(',')
         if "new" in trace_options and "rexmit" in trace_options:
             trace_with_retransmission = True
         elif "rexmit" in trace_options:
             trace_retransmission = True
         else:
-            pass # "new" is default
+            pass  # "new" is default
     if args.get("dns") or args.get("dnstcp"):
         do_traceroute = True
         name_prefix += "dns"

--- a/utils/convert_packetlist.py
+++ b/utils/convert_packetlist.py
@@ -14,10 +14,12 @@ def packet2json(packet_obj):
         elif '=' in line:
             key, val = line.split('=', 1)
             if layer == 'Raw' and key.strip() == 'load':
-                packet_dict[layer][key.strip()] = b64encode(packet_obj['Raw'].load).decode()
+                packet_dict[layer][key.strip()] = b64encode(
+                    packet_obj['Raw'].load).decode()
             else:
                 packet_dict[layer][key.strip()] = val.strip()
     return packet_dict
+
 
 def packetlist2json(answered, unanswered):
     packetlist = {'sent': [], 'received': []}

--- a/utils/convert_packetlist.py
+++ b/utils/convert_packetlist.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+from base64 import b64encode
+
+
+# this function source: https://stackoverflow.com/a/64410921
+def packet2json(packet_obj):
+    packet_dict = {}
+    layer = ''
+    for line in packet_obj.show2(dump=True).split('\n'):
+        if '###' in line:
+            layer = line.strip('#[] ')
+            packet_dict[layer] = {}
+        elif '=' in line:
+            key, val = line.split('=', 1)
+            if layer == 'Raw' and key.strip() == 'load':
+                packet_dict[layer][key.strip()] = b64encode(packet_obj['Raw'].load).decode()
+            else:
+                packet_dict[layer][key.strip()] = val.strip()
+    return packet_dict
+
+def packetlist2json(answered, unanswered):
+    packetlist = {'sent': [], 'received': []}
+    if len(answered) == 0:
+        if len(unanswered) != 0:
+            packetlist["sent"] = packet2json(packet_obj=unanswered[0])
+    else:
+        for sentp, receivedp in answered:
+            if len(packetlist["sent"]) == 0:
+                packetlist["sent"] = packet2json(packet_obj=sentp)
+            packetlist["received"].append(
+                packet2json(packet_obj=receivedp))
+    return packetlist

--- a/utils/trace.py
+++ b/utils/trace.py
@@ -612,8 +612,6 @@ def trace_route(
                     " ********************************************************************** ")
                 print(
                     " ********************************************************************** ")
-                data_path = save_measurement_data(
-                    request_ips, measurement_name, continue_to_max_ttl, output_dir)
     if was_successful:
         print("saving measurement data...")
         data_path = save_measurement_data(

--- a/utils/trace.py
+++ b/utils/trace.py
@@ -50,10 +50,7 @@ def choose_desirable_packet(request_and_answers, do_tcphandshake):
         elif request_and_answers[0][1][TCP].flags == "A" and request_and_answers[0][1].haslayer(Raw):
             desirable_packet = request_and_answers[0]
         else:
-            desirable_packet = request_and_answers[0]
-        return desirable_packet, summary_postfix
-    elif do_tcphandshake:
-        desirable_packet = request_and_answers[0]
+            return None, ""
         return desirable_packet, summary_postfix
     else:
         desirable_packet = request_and_answers[0]

--- a/utils/trace.py
+++ b/utils/trace.py
@@ -339,7 +339,7 @@ def initialize_first_nodes_json(request_ips):
 
 def initialize_json_first_nodes(
         request_ips, annotation_1, annotation_2, packet_1_proto, packet_2_proto,
-        packet_1_port, packet_2_port, packet_1_size, packet_2_size):
+        packet_1_port, packet_2_port, packet_1_size, packet_2_size, paris_id):
     # source_address = get_if_addr(conf.iface) #todo: xhdix
     source_address = SOURCE_IP_ADDRESS
     start_time = int(datetime.utcnow().timestamp())
@@ -348,7 +348,7 @@ def initialize_json_first_nodes(
             traceroute_data(
                 dst_addr=request_ip, annotation=annotation_1,
                 src_addr=source_address, proto=packet_1_proto, port=packet_1_port,
-                timestamp=start_time, size=packet_1_size
+                timestamp=start_time, paris_id=paris_id, size=packet_1_size
             )
         )
         if have_2_packet:
@@ -356,7 +356,7 @@ def initialize_json_first_nodes(
                 traceroute_data(
                     dst_addr=request_ip, annotation=annotation_2,
                     src_addr=source_address, proto=packet_2_proto, port=packet_2_port,
-                    timestamp=start_time, size=packet_2_size
+                    timestamp=start_time, paris_id=paris_id, size=packet_2_size
                 )
             )
 
@@ -519,11 +519,16 @@ def trace_route(
     repeat_all_steps = 0
     p1_proto, p2_proto, p1_port, p2_port, p1_size, p2_size = get_packets_info(
         request_packets)
+    paris_id = 0
+    if trace_with_retransmission:
+        paris_id = repeat_requests
+    elif trace_retransmission:
+        paris_id = -1
     initialize_json_first_nodes(
         request_ips=request_ips, annotation_1=annotation_1, annotation_2=annotation_2,
         packet_1_proto=p1_proto, packet_2_proto=p2_proto,
         packet_1_port=p1_port, packet_2_port=p2_port,
-        packet_1_size=p1_size, packet_2_size=p2_size
+        packet_1_size=p1_size, packet_2_size=p2_size, paris_id=paris_id
     )
     print("- · - · -     - · - · -     - · - · -     - · - · -")
     while repeat_all_steps < repeat_requests:

--- a/utils/trace.py
+++ b/utils/trace.py
@@ -86,9 +86,9 @@ def parse_packet(answered, unanswered, current_ttl, elapsed_ms, do_tcphandshake)
                 elapsed_ms = packet_elapsed_ms
             backttl = guess_back_ttl(current_ttl, req_answer[IP].ttl)
             print("   <<< answer:"
-                + "   ip.src: " + req_answer[IP].src
-                + "   ip.ttl: " + str(req_answer[IP].ttl)
-                + "   back-ttl: " + str(backttl))
+                  + "   ip.src: " + req_answer[IP].src
+                  + "   ip.ttl: " + str(req_answer[IP].ttl)
+                  + "   back-ttl: " + str(backttl))
             answer_summary = req_answer.summary()
             print("      " + answer_summary)
             print("· - · · · rtt: " + str(elapsed_ms) + "ms · · · - · ")
@@ -98,7 +98,7 @@ def parse_packet(answered, unanswered, current_ttl, elapsed_ms, do_tcphandshake)
     # else for both:
     print("              *** no response *** ")
     print("· - · · · rtt: " + str(elapsed_ms) +
-            "ms · · · · · · · · timeout ")
+          "ms · · · · · · · · timeout ")
     return "***", elapsed_ms, 0, 0, "*", answered, unanswered
 
 

--- a/utils/traceroute_struct.py
+++ b/utils/traceroute_struct.py
@@ -56,6 +56,7 @@ class traceroute_data:
     def set_endtime(self, endtime):
         self.endtime = endtime
 
+    # this function source: https://stackoverflow.com/a/64410921
     def packet2json(self, packet):
         packet_dict = {}
         for line in packet.show2(dump=True).split('\n'):

--- a/utils/traceroute_struct.py
+++ b/utils/traceroute_struct.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import json
+import utils.convert_packetlist
 
 
 class traceroute_data:
@@ -37,13 +38,13 @@ class traceroute_data:
                 "x": "-",
             })
         elif from_ip == "***":
-            packetlist = self.packetlist2json(answered, unanswered)
+            packetlist = utils.convert_packetlist.packetlist2json(answered, unanswered)
             self.result[hop - 1]["result"].append({
                 "x": "*",
                 "packets": packetlist,
             })
         else:
-            packetlist = self.packetlist2json(answered, unanswered)
+            packetlist = utils.convert_packetlist.packetlist2json(answered, unanswered)
             self.result[hop - 1]["result"].append({
                 "from": from_ip,
                 "rtt": rtt,
@@ -55,31 +56,6 @@ class traceroute_data:
 
     def set_endtime(self, endtime):
         self.endtime = endtime
-
-    # this function source: https://stackoverflow.com/a/64410921
-    def packet2json(self, packet):
-        packet_dict = {}
-        for line in packet.show2(dump=True).split('\n'):
-            if '###' in line:
-                layer = line.strip('#[] ')
-                packet_dict[layer] = {}
-            elif '=' in line:
-                key, val = line.split('=', 1)
-                packet_dict[layer][key.strip()] = val.strip()
-        return packet_dict
-
-    def packetlist2json(self, answered, unanswered):
-        packetlist = {'sent': [], 'received': []}
-        if len(answered) == 0:
-            if len(unanswered) != 0:
-                packetlist["sent"] = self.packet2json(packet=unanswered[0])
-        else:
-            for sentp, receivedp in answered:
-                if len(packetlist["sent"]) == 0:
-                    packetlist["sent"] = self.packet2json(packet=sentp)
-                packetlist["received"].append(
-                    self.packet2json(packet=receivedp))
-        return packetlist
 
     def clean_extra_result(self):
         result_index = 0

--- a/utils/traceroute_struct.py
+++ b/utils/traceroute_struct.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import json
+
 import utils.convert_packetlist
 
 
@@ -38,13 +39,15 @@ class traceroute_data:
                 "x": "-",
             })
         elif from_ip == "***":
-            packetlist = utils.convert_packetlist.packetlist2json(answered, unanswered)
+            packetlist = utils.convert_packetlist.packetlist2json(
+                answered, unanswered)
             self.result[hop - 1]["result"].append({
                 "x": "*",
                 "packets": packetlist,
             })
         else:
-            packetlist = utils.convert_packetlist.packetlist2json(answered, unanswered)
+            packetlist = utils.convert_packetlist.packetlist2json(
+                answered, unanswered)
             self.result[hop - 1]["result"].append({
                 "from": from_ip,
                 "rtt": rtt,

--- a/utils/vis.py
+++ b/utils/vis.py
@@ -11,11 +11,18 @@ ROUTER_COLOR = "green"
 WINDOWS_COLOR = "blue"
 LINUX_COLOR = "purple"
 MIDDLEBOX_COLOR = "red"
+PEP_COLOR = "green"
+NAT_COLOR = "dodgerblue"
 NO_RESPONSE_COLOR = "gray"
-DEVICE_OS_NAME = {
-    ROUTER_COLOR: "Router", WINDOWS_COLOR: "Windows", LINUX_COLOR: "Linux",
-    MIDDLEBOX_COLOR: "Middlebox", NO_RESPONSE_COLOR: "unknown"
-}
+
+ROUTER_NAME = "Router"
+WINDOWS_NAME = "Windows"
+LINUX_NAME = "Linux"
+MIDDLEBOX_NAME = "Middlebox"
+PEP_NAME = "PEP"
+NAT_NAME = "NAT"
+NO_RESPONSE_NAME = "unknown"
+
 REQUEST_COLORS = [
     "DarkTurquoise", "HotPink", "LimeGreen", "Red", "DodgerBlue", "Orange",
     "MediumSlateBlue", "DarkGoldenrod", "Green", "Brown", "YellowGreen", "Magenta"
@@ -28,22 +35,89 @@ TEMPLATE_PATH = os.path.dirname(
 multi_directed_graph = nx.MultiDiGraph()
 
 
+def get_packet_type(packet_obj):
+    if len(packet_obj.keys()) > 1:
+        return list(packet_obj.keys())[1]
+
+
+def detect_nat_middlebox(sent, received):
+    is_nat = False
+    is_middlebox = False
+    is_pep = False
+    packet_type = ""
+    tcpflag = ""
+    if not 'ICMP' in received[0].keys():
+        desirable_packet = None
+        # sent packet 1 = {}
+        # received packets = [
+        #                     {received packet 1},
+        #                     {received packet 2},
+        #                     {received packet 3}
+        #                    ]
+        if len(received) > 1:
+            if received[0]['TCP']['flags'] == "A" and 'ICMP' in received[1].keys():
+                is_pep = True
+                packet_type = get_packet_type(received[1])
+                if 'ICMP' in received[1].keys():
+                    if received[1]['IP in ICMP']['id'] != sent['IP']['id']:
+                        is_nat = True
+            if received[0]['TCP']['flags'] in ["R", "RA", "F", "FA"] and 'ICMP' in received[1].keys():
+                is_pep = True
+                is_middlebox = True
+                packet_type = get_packet_type(received[1])
+                if 'ICMP' in received[1].keys():
+                    if received[1]['IP in ICMP']['id'] != sent['IP']['id']:
+                        is_nat = True
+            elif received[0]['TCP']['flags'] in ["R", "RA", "F", "FA"]:
+                packet_type = get_packet_type(received[0])
+                if received[0]['IP']['id'] == sent['IP']['id']:
+                    is_middlebox = True
+            else:
+                packet_type = get_packet_type(received[1])
+                if received[1]['IP']['id'] == sent['IP']['id']:
+                    is_middlebox = True
+        # we need hello from server, not ACK from middlebox
+        elif received[0]['TCP']['flags'] != "A":
+            packet_type = get_packet_type(received[0])
+            if received[0]['IP']['id'] == sent['IP']['id']:
+                is_middlebox = True
+        # here we just want to have a correct path, so we ignore the lack of ACK before Server Hello in some weird networks
+        elif received[0]['TCP']['flags'] == "A" and received[0].haslayer('Raw'):
+            packet_type = get_packet_type(received[0])
+            if received[0]['IP']['id'] == sent['IP']['id']:
+                is_middlebox = True
+        else:
+            pass  # todo xhdix
+    else:
+        packet_type = 'ICMP'
+        if received[0]['IP in ICMP']['id'] != sent['IP']['id']:
+            is_nat = True
+    return is_nat, is_middlebox, is_pep, packet_type, tcpflag
+
+
 def parse_ttl(response_ttl, current_ttl):
     device_color = ""
     backttl = 0
+    is_middlebox = False
+    device_os_name = ""
     if response_ttl <= 20:
         backttl = int((current_ttl - response_ttl) / 2) + 1
         device_color = MIDDLEBOX_COLOR
+        is_middlebox = True
+        device_os_name = MIDDLEBOX_NAME
     elif response_ttl <= 64:
         backttl = 64 - response_ttl + 1
         device_color = LINUX_COLOR
+        device_os_name = LINUX_NAME
     elif response_ttl <= 128:
         backttl = 128 - response_ttl + 1
         device_color = WINDOWS_COLOR
+        device_os_name = WINDOWS_NAME
     else:
         backttl = 255 - response_ttl + 1
         device_color = ROUTER_COLOR
-    return backttl, device_color
+        device_os_name = ROUTER_NAME
+    return backttl, device_color, device_os_name, is_middlebox
 
 
 def visualize(previous_node_id, current_node_id,
@@ -58,9 +132,20 @@ def visualize(previous_node_id, current_node_id,
                                   color=requset_color, title=current_edge_title)
 
 
+def tooltips_append_lines(is_nat, is_middlebox, is_pep, packet_type, tcpflag):
+    append_line = ''
+    if packet_type == "TCP":
+        append_line = "<br/>response TCP flag: " + tcpflag
+    return ("<br/>NAT: " + str(is_nat)
+            + "<br/>Middlebox: " + str(is_middlebox)
+            + "<br/>PEP: " + str(is_pep)
+            + "<br/>response packet: " + packet_type
+            + append_line)
+
+
 def styled_tooltips(
-        current_request_colors, current_ttl_str, backttl, request_ip, elapsed_ms,
-        packet_size, repeat_all_steps, device_os_name, annotation):
+        current_request_color, current_ttl_str, backttl, request_ip, elapsed_ms,
+        packet_size, repeat_step, device_os_name, append_lines, annotation):
     time_size = "*"
     elapsed_ms_str = "*"
     packet_size_str = "*"
@@ -69,30 +154,37 @@ def styled_tooltips(
     if elapsed_ms != "*":
         elapsed_ms_str = str(format(elapsed_ms, '.3f')) + "ms"
         time_size = str(format(elapsed_ms/packet_size, '.3f')) + "ms/B"
-    return ("<pre style=\"color:" + current_request_colors
-            + "\">TTL: " + current_ttl_str
-            + "<br/>Back-TTL: " + backttl
-            + "<br/>Request to: " + request_ip
-            + "<br/>annotation: " + annotation
-            + "<br/>Time: " + elapsed_ms_str
-            + "<br/>Size: " + packet_size_str
-            + "<br/>Time/Size: " + time_size
-            + "<br/>OS: " + device_os_name
-            + "<br/>Repeat step: " + str(repeat_all_steps) + "</pre>")
+    tooltips_str = "<pre style=\"color:" + current_request_color
+    tooltips_str += "\">TTL: " + current_ttl_str
+    tooltips_str += "<br/>Back-TTL: " + backttl
+    tooltips_str += "<br/>Request to: " + request_ip
+    tooltips_str += "<br/>annotation: " + annotation
+    tooltips_str += "<br/>Time: " + elapsed_ms_str
+    tooltips_str += "<br/>Size: " + packet_size_str
+    tooltips_str += "<br/>Time/Size: " + time_size
+    tooltips_str += "<br/>OS: " + device_os_name
+    tooltips_str += append_lines
+    tooltips_str += "<br/>Repeat step: " + repeat_step + "</pre>"
+    return tooltips_str
 
 
-def already_reached_destination(previous_node_id, current_node_ip):
-    if previous_node_id in {
-            str(current_node_ip),
-            ("middlebox" + str(current_node_ip) + "x")}:
+def already_reached_destination_str(previous_node_id, dst_addr_id):
+    if dst_addr_id in previous_node_id:
         return True
     else:
         return False
 
 
-def initialize_first_nodes(src_addr):
+def initialize_detected(length_all):
     nodes = []
-    for _ in range(10):
+    for _ in range(length_all):
+        nodes.append({"is_nat": False, "is_middlebox": False, "is_pep": False})
+    return nodes
+
+
+def initialize_first_nodes_nx(src_addr, length_all):
+    nodes = []
+    for _ in range(length_all):
         nodes.append(str(src_addr))
     return nodes
 
@@ -118,29 +210,32 @@ def vis(measurement_path, attach_jscss, edge_lable: str = "none"):
         all_measurements = json.load(json_file)
     measurement_steps = 0
     src_addr = all_measurements[0]["src_addr"]
-    src_addr_id = str(int(ipaddress.IPv4Address(src_addr)))
+    src_addr_id = 'x' + str(int(ipaddress.IPv4Address(src_addr))) + 'x'
     multi_directed_graph.add_node(
         src_addr_id, label=src_addr, color="Chocolate", title="source address",
         shape="diamond")
     for measurement in all_measurements:
-        previous_node_ids = initialize_first_nodes(src_addr_id)
         dst_addr = measurement["dst_addr"]
-        dst_addr_id = str(int(ipaddress.IPv4Address(dst_addr)))
+        dst_addr_id = 'x' + str(int(ipaddress.IPv4Address(dst_addr))) + 'x'
         annotation = "-"
         if "annotation" in measurement.keys():
             annotation = measurement["annotation"]
         all_results = measurement["result"]
+        results_repeat_length = len(all_results[0]["result"])
+        previous_node_ids = initialize_first_nodes_nx(
+            src_addr_id, results_repeat_length)
+        already_detected = initialize_detected(results_repeat_length)
         for try_step in all_results:  # will be up to 255
             current_ttl = try_step["hop"]
             current_ttl_str = str(current_ttl)
             results = try_step["result"]
             repeat_steps = 0
             skip_next = False
-            for result in results:  # will be up to 3
+            for result in results:
                 if skip_next:
                     skip_next = False
                     continue
-                not_yet_destination = not (already_reached_destination(
+                not_yet_destination = not (already_reached_destination_str(
                     previous_node_ids[repeat_steps], dst_addr_id))
                 if not_yet_destination:
                     if "late" in result.keys():
@@ -154,6 +249,8 @@ def vis(measurement_path, attach_jscss, edge_lable: str = "none"):
                     packet_size = "*"
                     backttl = "*"
                     device_color = NO_RESPONSE_COLOR
+                    device_name = NO_RESPONSE_NAME
+                    append_lines = ""
                     if 'x' in result.keys():
                         current_node_id = (
                             "unknown" + previous_node_ids[repeat_steps] + "x")
@@ -161,7 +258,7 @@ def vis(measurement_path, attach_jscss, edge_lable: str = "none"):
                             current_edge_label = "*"
                     else:
                         answer_ip = result["from"]
-                        backttl, device_color = parse_ttl(
+                        backttl, device_color, device_name, is_middlebox_ttl = parse_ttl(
                             result["ttl"], current_ttl)
                         if "rtt" in result.keys():
                             elapsed_ms = result["rtt"]
@@ -170,26 +267,49 @@ def vis(measurement_path, attach_jscss, edge_lable: str = "none"):
                                 current_edge_label = format(elapsed_ms, '.3f')
                         elif edge_lable == "backttl":
                             current_edge_label = str(backttl)
-                        current_node_id = str(
-                            int(ipaddress.IPv4Address(answer_ip)))
-                        if device_color == MIDDLEBOX_COLOR:
-                            current_node_id = (
-                                "middlebox" + str(current_node_id) + "x")
+                        current_node_id = 'x' + str(
+                            int(ipaddress.IPv4Address(answer_ip))) + 'x'
+                        if "packets" in result.keys():
+                            if "received" in result['packets'].keys():
+                                if len(result['packets']['received']) != 0:
+                                    is_nat, is_middlebox, is_pep, packet_type, tcpflag = detect_nat_middlebox(
+                                        result['packets']['sent'], result['packets']['received']
+                                    )
+                                    if (is_middlebox_ttl or is_middlebox
+                                        ) and not already_detected[repeat_steps]["is_middlebox"]:
+                                        already_detected[repeat_steps]["is_middlebox"] = True
+                                    elif is_pep and not already_detected[repeat_steps]["is_pep"]:
+                                        device_color = PEP_COLOR
+                                        current_node_shape = "star"
+                                        already_detected[repeat_steps]["is_pep"] = True
+                                        current_node_id = "pep" + current_node_id + "x"
+                                    elif is_nat and not already_detected[repeat_steps]["is_nat"]:
+                                        device_color = NAT_COLOR
+                                        already_detected[repeat_steps]["is_nat"] = True
+                                        current_node_id = "nat" + current_node_id + "x"
+                                    append_lines = tooltips_append_lines(
+                                        is_nat, is_middlebox, is_pep, packet_type, tcpflag)
+                        if is_middlebox_ttl or is_middlebox:
+                            current_node_id = "middlebox" + current_node_id + "x"
                             current_node_shape = "star"
+                            device_color = MIDDLEBOX_COLOR
+                            already_detected[repeat_steps]["is_middlebox"] = True
                         elif current_node_id == dst_addr_id:
                             current_node_shape = "square"
                         current_node_label = answer_ip
-                        current_edge_title = str(backttl)
                         packet_size = result["size"]
+                    repeat_step_str = str(repeat_steps + 1)
                     current_edge_title = styled_tooltips(
-                        REQUEST_COLORS[measurement_steps], current_ttl_str,
-                        str(backttl), dst_addr, elapsed_ms, packet_size,
-                        (repeat_steps + 1), DEVICE_OS_NAME[device_color],
-                        annotation
+                        current_request_color=(REQUEST_COLORS[measurement_steps]),
+                        current_ttl_str=current_ttl_str, backttl=str(backttl),
+                        request_ip=dst_addr, elapsed_ms=elapsed_ms,
+                        packet_size=packet_size, repeat_step=repeat_step_str,
+                        device_os_name=device_name, append_lines=append_lines,
+                        annotation=annotation
                     )
                     visualize(
                         previous_node_ids[repeat_steps], current_node_id,
-                        current_node_label, DEVICE_OS_NAME[device_color], device_color,
+                        current_node_label, device_name, device_color,
                         current_edge_title, REQUEST_COLORS[measurement_steps],
                         current_edge_label, current_node_shape
                     )

--- a/utils/vis.py
+++ b/utils/vis.py
@@ -281,8 +281,8 @@ def vis(measurement_path, attach_jscss, edge_lable: str = "none"):
                                         result['packets']['sent'], result['packets']['received']
                                     )
                                     if (is_middlebox_ttl or is_middlebox
-                                        ) and not already_detected[repeat_steps]["is_middlebox"]:
-                                        pass # we decide about it later
+                                            ) and not already_detected[repeat_steps]["is_middlebox"]:
+                                        pass  # we decide about it later
                                     elif is_pep and not already_detected[repeat_steps]["is_pep"]:
                                         device_color = PEP_COLOR
                                         device_name = PEP_NAME
@@ -314,7 +314,8 @@ def vis(measurement_path, attach_jscss, edge_lable: str = "none"):
                         packet_size = result["size"]
                     repeat_step_str = str(repeat_steps + 1)
                     current_edge_title = styled_tooltips(
-                        current_request_color=(REQUEST_COLORS[measurement_steps]),
+                        current_request_color=(
+                            REQUEST_COLORS[measurement_steps]),
                         current_ttl_str=current_ttl_str, backttl=str(backttl),
                         request_ip=dst_addr, elapsed_ms=elapsed_ms,
                         packet_size=packet_size, repeat_step=repeat_step_str,

--- a/utils/vis.py
+++ b/utils/vis.py
@@ -258,6 +258,7 @@ def vis(measurement_path, attach_jscss, edge_lable: str = "none"):
                     device_color = NO_RESPONSE_COLOR
                     device_name = NO_RESPONSE_NAME
                     append_lines = ""
+                    is_middlebox = False
                     if 'x' in result.keys():
                         current_node_id = (
                             "unknown" + previous_node_ids[repeat_steps] + "x")


### PR DESCRIPTION
we have the ability to trace the route like Paris-traceroute: ` -o "new,rexmit"`. https://paris-traceroute.net/

but now, detecting NAT is nice thing to do. just like Dublin-traceroute: https://dublin-traceroute.net/

about PEP: https://datatracker.ietf.org/doc/html/rfc3135#section-3.1.2