### PR TITLE
Feature/logger

### DIFF
--- a/tracevis.py
+++ b/tracevis.py
@@ -13,10 +13,13 @@ import utils.trace
 import utils.vis
 
 import textwrap
+import logging
 
 import json
 from copy import deepcopy
 
+logging.basicConfig(level=logging.DEBUG, format='%(message)s')
+logger = logging.getLogger(__name__)
 
 TIMEOUT = 1
 MAX_TTL = 50
@@ -204,10 +207,10 @@ def main(args):
             else:
                 raise RuntimeError("Bad input type")
         except (utils.packet_input.BADPacketException, utils.packet_input.FirewallException) as e:
-            print(f"{e!s}")
+            logger.error(f"{e!s}")
             exit(1)
         except Exception as e:
-            print(f"Error!\n{e!s}")
+            logger.error(f"Error!\n{e!s}")
             exit(2)
 
         if do_tcph1 or do_tcph2:
@@ -218,25 +221,15 @@ def main(args):
         if args.get("packet") or args.get("rexmit"):
             with input_packet as ctx:
                 packet_1, packet_2, do_tcph1, do_tcph2 = ctx
-                was_successful, measurement_path = utils.trace.trace_route(
-                    ip_list=request_ips, request_packet_1=packet_1, output_dir=output_dir,
-                    max_ttl=max_ttl, timeout=timeout, repeat_requests=repeat_requests,
-                    request_packet_2=packet_2, name_prefix=name_prefix,
-                    annotation_1=annotation_1, annotation_2=annotation_2,
-                    continue_to_max_ttl=continue_to_max_ttl,
-                    do_tcph1=do_tcph1, do_tcph2=do_tcph2,
-                    trace_retransmission=trace_retransmission,
-                    trace_with_retransmission=trace_with_retransmission)
-        else:
-            was_successful, measurement_path = utils.trace.trace_route(
-                ip_list=request_ips, request_packet_1=packet_1, output_dir=output_dir,
-                max_ttl=max_ttl, timeout=timeout, repeat_requests=repeat_requests,
-                request_packet_2=packet_2, name_prefix=name_prefix,
-                annotation_1=annotation_1, annotation_2=annotation_2,
-                continue_to_max_ttl=continue_to_max_ttl,
-                do_tcph1=do_tcph1, do_tcph2=do_tcph2,
-                trace_retransmission=trace_retransmission,
-                trace_with_retransmission=trace_with_retransmission)
+        was_successful, measurement_path = utils.trace.trace_route(
+            ip_list=request_ips, request_packet_1=packet_1, output_dir=output_dir,
+            max_ttl=max_ttl, timeout=timeout, repeat_requests=repeat_requests,
+            request_packet_2=packet_2, name_prefix=name_prefix,
+            annotation_1=annotation_1, annotation_2=annotation_2,
+            continue_to_max_ttl=continue_to_max_ttl,
+            do_tcph1=do_tcph1, do_tcph2=do_tcph2,
+            trace_retransmission=trace_retransmission,
+            trace_with_retransmission=trace_with_retransmission)
     if args.get("ripe"):
         measurement_ids = ""
         if args.get("ripemids"):
@@ -260,7 +253,7 @@ def main(args):
         if utils.vis.vis(
                 measurement_path=measurement_path, attach_jscss=attach_jscss,
                 edge_lable=edge_lable):
-            print("finished.")
+            logger.info("finished.")
 
 
 if __name__ == "__main__":

--- a/utils/csv.py
+++ b/utils/csv.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import json
 import os.path
+import logging 
+logger = logging.getLogger(__name__)
 
 csv_header_all = ""
 csv_blank_row = ""
@@ -27,7 +29,7 @@ def parse_json(file_name: str) -> list:
     try:
         json_data = json.loads(json_str)
     except:
-        print("JSON format is not valid!")
+        logger.error("JSON format is not valid!")
         return ""
     for measurement in json_data:
         dst_addr = measurement["dst_addr"]
@@ -114,8 +116,8 @@ def json2csv(file_name: str, sort_it: bool = True):
                 data = sorted(data, key=lambda d: d['hop'])
             csv = data_to_csv(data, sort_it)
             if csv != "": # todo (xhdix): it will never be empty. we shold do better
-                print("saving measurement in csv...")
+                logger.info("saving measurement in csv...")
                 csvfile.write(csv)
-                print("saved: " + new_file_name)
+                logger.info("saved: " + new_file_name)
     else:
-        print("error: " + file_name + " does not exist!")
+        logger.error("error: " + file_name + " does not exist!")

--- a/utils/packet_input.py
+++ b/utils/packet_input.py
@@ -4,7 +4,8 @@ from scapy.utils import import_hexcap
 import subprocess
 import base64
 import json 
-
+import logging
+logger = logging.getLogger(__name__)
 
 FIREWALL_COMMANDS_HELP = "\r\n( · - · · · \r\n\
 You may need to temporarily block RST output packets in your firewall.\r\n\
@@ -111,9 +112,9 @@ class InputPacketInfo:
         if not  cls._supported_or_correct(p1):
             raise BADPacketException("it's not IPv4 or the hexdump is not started with IP layer")
         if show:
-            print(" . . . - . developed view of this packet:")
+            logger.debug(" . . . - . developed view of this packet:")
             p1.show()
-            print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+            logger.debug(" . . . - .     . . . - .     . . . - .     . . . - . ")
         return p1
 
 
@@ -139,7 +140,7 @@ class InputPacketInfo:
                         raise FirewallException("No iptables!")
                 else:
                     do_tcph1 = cls._ask_yesno("Would you like to do a TCP Handshake before sending this packet?")
-                print(" · - · - ·     · - · - ·     · - · - ·     · - · - · ")
+                logger.info(" · - · - ·     · - · - ·     · - · - ·     · - · - · ")
 
                     
             if cls._ask_yesno("Would you like to add a second packet"):
@@ -147,7 +148,7 @@ class InputPacketInfo:
                 if copy_packet_2.haslayer(TCP):
                     if copy_packet_2[TCP].flags == "PA":
                         do_tcph2 = cls._ask_yesno("Would you like to do a TCP Handshake before sending this packet?")
-        print(" ********************************************************************** ")
+        logger.info(" ********************************************************************** ")
         return InputPacketInfo(copy_packet_1, copy_packet_2, do_tcph1,  do_tcph2, add_firewall_rule)
 
     @classmethod
@@ -155,13 +156,13 @@ class InputPacketInfo:
         if json_config[k]['hex'].startswith("b64:"):
             json_config[k]['hex'] = base64.b64decode(json_config[k]['hex'][4:].strip()).decode()
         packet = IP(import_hexcap(json_config[k]['hex']))
-        print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-        print(" . . . - . developed view of first packet:")
+        logger.info(" . . . - .     . . . - .     . . . - .     . . . - . ")
+        logger.info(" . . . - . developed view of first packet:")
         if not cls._supported_or_correct(packet):
             BADPacketException(f"{k} it's not IPv4 or the hexdump is not started with IP layer")
         if show:
             packet.show()
-            print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+            logger.info(" . . . - .     . . . - .     . . . - .     . . . - . ")
         return packet
         
     @classmethod
@@ -185,9 +186,9 @@ class InputPacketInfo:
                         if copy_packet_2[TCP].flags == "PA":
                             do_tcph2 = json_config['packet2'].get('handshake', False)
             add_firewall_rule = json_config.get('add_firewall_drop', False)            
-            print(" ********************************************************************** ")
+            logger.info(" ********************************************************************** ")
         except FileNotFoundError:
-            print(f" · · · · · · · · file '{file}' not found!.")
+            logger.error(f" · · · · · · · · file '{file}' not found!.")
             raise BADPacketException("File Not Found")
         return InputPacketInfo(copy_packet_1, copy_packet_2, do_tcph1,  do_tcph2, add_firewall_rule)
 
@@ -210,10 +211,10 @@ class InputPacketInfo:
         if not cls._supported_or_correct(packet):
             raise BADPacketException("it's not IPv4 or the hexdump is not started with IP layer")
         if show:
-            print(" . . . - .     . . . - .     . . . - .     . . . - . ")
-            print(" . . . - . developed view of first packet:")
+            logger.debug(" . . . - .     . . . - .     . . . - .     . . . - . ")
+            logger.debug(" . . . - . developed view of first packet:")
             packet.show()
-            print(" . . . - .     . . . - .     . . . - .     . . . - . ")
+            logger.debug(" . . . - .     . . . - .     . . . - .     . . . - . ")
         return packet
 
     @classmethod
@@ -237,12 +238,12 @@ class InputPacketInfo:
                     raise FirewallException("No iptables!")
             else:
                 do_tcph1 = cls._ask_yesno("Would you like to do a TCP Handshake before sending this packet?")
-            print(" · - · - ·     · - · - ·     · - · - ·     · - · - · ")
+            logger.info(" · - · - ·     · - · - ·     · - · - ·     · - · - · ")
 
             if cls._ask_yesno("Would you like to add a second packet"):
                 copy_packet_2 = cls._read_interactive_packet(show=True)
                 if copy_packet_2.haslayer(TCP) and copy_packet_2[TCP].flags == "PA":
                     do_tcph2 = cls._ask_yesno("Would you like to do a TCP Handshake before sending this packet?")
-        print(" ********************************************************************** ")
+        logger.info(" ********************************************************************** ")
         return InputPacketInfo(copy_packet_1, copy_packet_2, do_tcph1,  do_tcph2, add_firewall_rule)
 

--- a/utils/ripe_atlas.py
+++ b/utils/ripe_atlas.py
@@ -4,6 +4,8 @@ import json
 import urllib.request
 from datetime import datetime
 from time import sleep
+import logging 
+logger = logging.getLogger(__name__)
 
 
 MEASUREMENT_IDS = [
@@ -34,14 +36,11 @@ def download_from_atlas(
         measurement_name = "ripe-atlas-" + str(probe_id) + "-tracevis-" \
             + datetime.utcnow().strftime("%Y%m%d-%H%M")
     if probe_id != "":
-        print(
-            " ********************************************************************** ")
-        print(
-            "downloading data from probe ID: " + str(probe_id))
-        print(" · · · - - - · · ·     · · · - - - · · ·     · · · - - - · · · ")
+        logger.info(" ********************************************************************** ")
+        logger.info("downloading data from probe ID: " + str(probe_id))
+        logger.info(" · · · - - - · · ·     · · · - - - · · ·     · · · - - - · · · ")
         for measurement_id in measurement_ids:
-            print(
-                "downloading measurement ID: " + str(measurement_id))
+            logger.info("downloading measurement ID: " + str(measurement_id))
             requset_url = ("https://atlas.ripe.net/api/v2/measurements/"
                            + str(measurement_id)
                            + "/latest/?format=json&probe_ids="
@@ -51,24 +50,20 @@ def download_from_atlas(
                 downloaded_data = json.loads(url.read().decode())
             if downloaded_data is not None:
                 all_measurements.append(downloaded_data[0])
-                print(
-                    "downloading measurement ID " + str(measurement_id) + " finished.")
+                logger.info("downloading measurement ID " + str(measurement_id) + " finished.")
             else:
-                print("failed to download measurement ID: "
-                      + str(measurement_id))
+                logger.error(f"failed to download measurement ID: {measurement_id!s}")
             sleep(3)
-            print(" · · · - - - · · ·     · · · - - - · · ·     · · · - - - · · · ")
-        print(
-            " ********************************************************************** ")
+            logger.info(" · · · - - - · · ·     · · · - - - · · ·     · · · - - - · · · ")
+        logger.info(" ********************************************************************** ")
         if len(all_measurements) < 1:
             exit()
         measurement_path = output_dir + measurement_name + ".json"
-        print("saving json file... to: " + measurement_path)
+        logger.info("saving json file... to: " + measurement_path)
         with open((measurement_path), 'w', encoding='utf-8') as json_file:
             json.dump(all_measurements, json_file,
                       ensure_ascii=False, indent=4)
-        print("saved: " + measurement_path)
+        logger.info("saved: " + measurement_path)
         was_successful = True
-        print(
-            " ********************************************************************** ")
+        logger.info(" ********************************************************************** ")
         return was_successful, measurement_path

--- a/utils/vis.py
+++ b/utils/vis.py
@@ -3,6 +3,8 @@
 import ipaddress
 import json
 import os
+import logging
+logger = logging.getLogger(__name__)
 
 import networkx as nx
 from pyvis.network import Network
@@ -254,7 +256,7 @@ def save_measurement_graph(graph_name, attach_jscss):
         graph_name = graph_name[:-5]
     graph_path = graph_name + ".html"
     net_vis.save_graph(graph_path)
-    print("saved: " + graph_path)
+    logger.info("saved: " + graph_path)
 
 
 def vis(measurement_path, attach_jscss, edge_lable: str = "none"):
@@ -381,6 +383,6 @@ def vis(measurement_path, attach_jscss, edge_lable: str = "none"):
                     previous_node_ids[repeat_steps] = current_node_id
                 repeat_steps += 1
         measurement_steps += 1
-    print("saving measurement graph...")
+    logger.info("saving measurement graph...")
     save_measurement_graph(measurement_path, attach_jscss)
-    print("· · · - · -     · · · - · -     · · · - · -     · · · - · -")
+    logger.info("· · · - · -     · · · - · -     · · · - · -     · · · - · -")


### PR DESCRIPTION
print messages are converted to logger messages
we now have `--log` CLI parameter which defaults to `debug` and prints all messages

- Obvious `error` and `warning` messages are in correct level.
- packet details are in `debug` level
- decorative, informative and Morse codes are in `info` level (Cleanup and enhancements are required)

Also current message format is `%(message)s` so only message itself is logged; we need to categorize sections/modules/functions and decide for a appropriate message format (time, section, level, message, ...) 