### PR TITLE
Feature: save pasted packet to config file

### DIFF
--- a/tracevis.py
+++ b/tracevis.py
@@ -26,10 +26,13 @@ DEFAULT_REQUEST_IPS = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
 OS_NAME = platform.system()
 
 
-def dump_non_default_args_to_file(file, args):
+def dump_non_default_args_to_file(file, args, packet_info):
     args_without_config_arg = args.copy()
     if 'config_file' in args_without_config_arg:
         del args_without_config_arg['config_file']
+    if packet_info:
+        args_without_config_arg['packet_data'] = packet_info.as_dict()
+        args_without_config_arg['packet_input_method'] = 'json'
     with open(file,'w') as f:
         json.dump(args_without_config_arg, f, indent=4, sort_keys=True)
 
@@ -120,6 +123,7 @@ def main(args):
         else:
             args['packet_data'] = json.loads(args.get('packet_data'))
 
+    input_packet = None 
     name_prefix = ""
     continue_to_max_ttl = False
     max_ttl = MAX_TTL
@@ -255,7 +259,7 @@ def main(args):
             was_successful = True
     if was_successful:
         config_dump_file_name = f"{os.path.splitext(measurement_path)[0]}.conf"
-        dump_non_default_args_to_file(config_dump_file_name, args)
+        dump_non_default_args_to_file(config_dump_file_name, args, input_packet)
         
         if utils.vis.vis(
                 measurement_path=measurement_path, attach_jscss=attach_jscss,

--- a/utils/packet_input.py
+++ b/utils/packet_input.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from scapy.layers.inet import IP, TCP
-from scapy.utils import import_hexcap
+from scapy.utils import import_hexcap, hexdump 
 import subprocess
 import base64
 import json 
@@ -30,6 +30,22 @@ class InputPacketInfo:
         self._do_tcph1 = do_tcph1
         self._do_tcph2 = do_tcph2
         self._add_firewall_rule = add_firewall_rule
+    
+    def as_dict(self):
+        
+        res = {
+            "packet1": {
+                'hex': 'b64:' + base64.b64encode(hexdump(self._packet1, True).encode()).decode(),
+                'handshake': self._do_tcph1,
+            },
+        }
+        if self._packet2:
+            res['packet2'] = {
+                    'hex': 'b64:' + base64.b64encode(hexdump(self._packet2, True).encode()).decode(),
+                    'handshake': self._do_tcph2,
+            }
+        res["add_firewall_drop"] = self._add_firewall_rule
+        return res 
 
     @property
     def params(self):


### PR DESCRIPTION
Before this saved config was a exact match of input arguments so if `hex` input method was selected, re-execution of application with `--config` argument required pasting packet again

Now the pasted packet is also dumped in config file and `packet_input_method` set to `json` so config can be executed again without packet paste. 