### PR TITLE
Make CONFIG file override-able from CLI

### DIFF
--- a/tracevis.py
+++ b/tracevis.py
@@ -130,8 +130,6 @@ def get_args():
 
     args = parser.parse_args()
     args_dict = process_input_args(args, parser)
-    if args_dict.get('packet_input_method') == 'file' and args_dict.get('packet_file') is None:
-        parser.error("--packet-input-method requires --packet-file.")
 
     return args_dict
 

--- a/tracevis.py
+++ b/tracevis.py
@@ -52,8 +52,11 @@ def process_input_args(args, parser):
         args_dict[k] = cli_args_dict.get(k)
 
     if 'dns' in passed_args:
-        args_dict['packet'] = None
+        args_dict['packet'] = False
         args_dict['packet_input_method'] = None
+    if 'packet' in passed_args:
+        args_dict['dns'] = False
+
     return args_dict
 
 


### PR DESCRIPTION
This enables users to override config file settings from CLI
Example:
if a config file says `--name` is `some name` user can run app like:
```bash
tracevis.py --config file.conf --name "new name"
```
If config contain `--packet` and cli contain `--dns` or vice versa, cli is preferred 