### PR TITLE
Fix: config override breaks no config file mode

### DIFF
--- a/tracevis.py
+++ b/tracevis.py
@@ -43,10 +43,10 @@ def process_input_args(args, parser):
         for opt in parser._option_string_actions.values()
         if hasattr(args, opt.dest) and opt.default != getattr(args, opt.dest)
     }
-    args_dict = {}
+    args_dict = cli_args_dict.copy()
     if args.config_file:
         with open(args.config_file) as f:
-            args_dict = json.load(f)
+            args_dict.update(json.load(f))
 
     for k in passed_args:
         args_dict[k] = cli_args_dict.get(k)


### PR DESCRIPTION
if no config file is (or with malformed config file) present then argument dict
will be empty so no default parameter will work

We should always use parsed arguments and then update it with loaded config file contents if it is present

