### PR TITLE
fix: iptables existence

### DIFF
--- a/tracevis.py
+++ b/tracevis.py
@@ -284,19 +284,23 @@ def main(args):
     if trace_with_retransmission:
         name_prefix += "-paristr"
     if do_traceroute:
-        if args.get("packet") or args.get("rexmit"):
-            with input_packet as ctx:
-                packet_1, packet_2, do_tcph1, do_tcph2 = ctx
-        was_successful, measurement_path, no_internet = utils.trace.trace_route(
-            ip_list=request_ips, request_packet_1=packet_1, output_dir=output_dir,
-            max_ttl=max_ttl, timeout=timeout, repeat_requests=repeat_requests,
-            request_packet_2=packet_2, name_prefix=name_prefix,
-            annotation_1=annotation_1, annotation_2=annotation_2,
-            continue_to_max_ttl=continue_to_max_ttl,
-            do_tcph1=do_tcph1, do_tcph2=do_tcph2,
-            trace_retransmission=trace_retransmission,
-            trace_with_retransmission=trace_with_retransmission, iface=iface,
-            dst_port=dst_port)
+        try:
+            if args.get("packet") or args.get("rexmit"):
+                with input_packet as ctx:
+                    packet_1, packet_2, do_tcph1, do_tcph2 = ctx
+            was_successful, measurement_path, no_internet = utils.trace.trace_route(
+                ip_list=request_ips, request_packet_1=packet_1, output_dir=output_dir,
+                max_ttl=max_ttl, timeout=timeout, repeat_requests=repeat_requests,
+                request_packet_2=packet_2, name_prefix=name_prefix,
+                annotation_1=annotation_1, annotation_2=annotation_2,
+                continue_to_max_ttl=continue_to_max_ttl,
+                do_tcph1=do_tcph1, do_tcph2=do_tcph2,
+                trace_retransmission=trace_retransmission,
+                trace_with_retransmission=trace_with_retransmission, iface=iface,
+                dst_port=dst_port)
+        except Exception as e:
+            print(f"Error!\n{e!s}")
+            exit(2)
         if no_internet:
             attach_jscss = True
     if args.get("ripe"):

--- a/utils/packet_input.py
+++ b/utils/packet_input.py
@@ -155,7 +155,7 @@ class InputPacketInfo:
                         add_firewall_rule = cls._ask_yesno(
                             f"{FIREWALL_COMMANDS_HELP}\n\nDo You want add rules automaticallly using iptables?")
                         
-                        if not cls._iptables_exists():
+                        if add_firewall_rule and not cls._iptables_exists():
                             # FIXME: WHAT IF NOT? FAIL?
                             raise FirewallException("iptables is not installed on this system, you may need use some other method to manually handle OS RST responses if these is such a problem!")
                 else:
@@ -260,7 +260,7 @@ class InputPacketInfo:
                 if not cls._check_firewal_out_drop_rule():
                     add_firewall_rule = cls._ask_yesno(
                         f"{FIREWALL_COMMANDS_HELP}\n\nDo You want add rules automaticallly using iptables?")
-                if not cls._iptables_exists():
+                if add_firewall_rule and  not cls._iptables_exists():
                     # FIXME: WHAT IF NOT? FAIL?
                     raise FirewallException("iptables is not installed on this system, you may need use some other method to manually handle OS RST responses if therese is such a problem!")
             else:

--- a/utils/packet_input.py
+++ b/utils/packet_input.py
@@ -157,7 +157,7 @@ class InputPacketInfo:
                         
                         if add_firewall_rule and not cls._iptables_exists():
                             # FIXME: WHAT IF NOT? FAIL?
-                            raise FirewallException("iptables is not installed on this system, you may need use some other method to manually handle OS RST responses if these is such a problem!")
+                            raise FirewallException("iptables is not installed on this system, you may need use some other method to manually handle OS RST responses if there is such a problem!")
                 else:
                     do_tcph1 = cls._ask_yesno(
                         "Would you like to do a TCP Handshake before sending this packet?")
@@ -262,7 +262,7 @@ class InputPacketInfo:
                         f"{FIREWALL_COMMANDS_HELP}\n\nDo You want add rules automaticallly using iptables?")
                 if add_firewall_rule and  not cls._iptables_exists():
                     # FIXME: WHAT IF NOT? FAIL?
-                    raise FirewallException("iptables is not installed on this system, you may need use some other method to manually handle OS RST responses if therese is such a problem!")
+                    raise FirewallException("iptables is not installed on this system, you may need use some other method to manually handle OS RST responses if there is such a problem!")
             else:
                 do_tcph1 = cls._ask_yesno(
                     "Would you like to do a TCP Handshake before sending this packet?")

--- a/utils/packet_input.py
+++ b/utils/packet_input.py
@@ -7,7 +7,7 @@ from scapy.all import IP, TCP, Ether, hexdump, import_hexcap
 
 FIREWALL_COMMANDS_HELP = "\r\n( · - · · · \r\n\
 You may need to temporarily block RST output packets in your firewall.\r\n\
-For example:\r\n\
+For example with iptables the commands are:\r\n\
 iptables -A OUTPUT -p tcp --tcp-flags RST RST -j DROP\r\n\
 After the test, you can delete it:\r\n\
 iptables -D OUTPUT -p tcp --tcp-flags RST RST -j DROP\r\n · - · - · )\r\n"
@@ -65,7 +65,7 @@ class InputPacketInfo:
             p = subprocess.run(['iptables', '-L', '-n'], check=True,
                                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             return True
-        except subprocess.CalledProcessError:
+        except:
             return False
 
     @classmethod
@@ -74,7 +74,7 @@ class InputPacketInfo:
             p = subprocess.run(['iptables', '-C', 'OUTPUT', '-p', 'tcp',
                                 '--tcp-flags', 'RST', 'RST', '-j', 'DROP'], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             return True
-        except subprocess.CalledProcessError:
+        except:
             return False
 
     @classmethod
@@ -149,15 +149,15 @@ class InputPacketInfo:
         if not trace_retransmission:
             if copy_packet_1.haslayer(TCP) and copy_packet_1[TCP].flags == "PA":
                 if os_name.lower() == "linux":
-                    if cls._iptables_exists():
-                        do_tcph1 = cls._ask_yesno(
+                    do_tcph1 = cls._ask_yesno(
                             f"Would you like to do a TCP Handshake before sending this packet?")
-                        if not cls._check_firewal_out_drop_rule():
-                            add_firewall_rule = cls._ask_yesno(
-                                f"{FIREWALL_COMMANDS_HELP}\n\nDo You want add rules automaticallly?")
-                    else:
-                        # FIXME: WHAT IF NOT? FAIL?
-                        raise FirewallException("No iptables!")
+                    if not cls._check_firewal_out_drop_rule():
+                        add_firewall_rule = cls._ask_yesno(
+                            f"{FIREWALL_COMMANDS_HELP}\n\nDo You want add rules automaticallly using iptables?")
+                        
+                        if not cls._iptables_exists():
+                            # FIXME: WHAT IF NOT? FAIL?
+                            raise FirewallException("No iptables!")
                 else:
                     do_tcph1 = cls._ask_yesno(
                         "Would you like to do a TCP Handshake before sending this packet?")
@@ -255,13 +255,12 @@ class InputPacketInfo:
         copy_packet_1 = cls._read_interactive_packet(show=True)
         if not trace_retransmission:
             if os_name.lower() == "linux":
-                if cls._iptables_exists():
-                    do_tcph1 = cls._ask_yesno(
-                        f"Would you like to do a TCP Handshake before sending this packet?")
-                    if not cls._check_firewal_out_drop_rule():
-                        add_firewall_rule = cls._ask_yesno(
-                            f"{FIREWALL_COMMANDS_HELP}\n\nDo You want add rules automaticallly?")
-                else:
+                do_tcph1 = cls._ask_yesno(
+                    f"Would you like to do a TCP Handshake before sending this packet?")
+                if not cls._check_firewal_out_drop_rule():
+                    add_firewall_rule = cls._ask_yesno(
+                        f"{FIREWALL_COMMANDS_HELP}\n\nDo You want add rules automaticallly using iptables?")
+                if not cls._iptables_exists():
                     # FIXME: WHAT IF NOT? FAIL?
                     raise FirewallException("No iptables!")
             else:

--- a/utils/packet_input.py
+++ b/utils/packet_input.py
@@ -157,7 +157,7 @@ class InputPacketInfo:
                         
                         if not cls._iptables_exists():
                             # FIXME: WHAT IF NOT? FAIL?
-                            raise FirewallException("No iptables!")
+                            raise FirewallException("iptables is not installed on this system, you may need use some other method to manually handle OS RST responses if these is such a problem!")
                 else:
                     do_tcph1 = cls._ask_yesno(
                         "Would you like to do a TCP Handshake before sending this packet?")
@@ -262,7 +262,7 @@ class InputPacketInfo:
                         f"{FIREWALL_COMMANDS_HELP}\n\nDo You want add rules automaticallly using iptables?")
                 if not cls._iptables_exists():
                     # FIXME: WHAT IF NOT? FAIL?
-                    raise FirewallException("No iptables!")
+                    raise FirewallException("iptables is not installed on this system, you may need use some other method to manually handle OS RST responses if therese is such a problem!")
             else:
                 do_tcph1 = cls._ask_yesno(
                     "Would you like to do a TCP Handshake before sending this packet?")

--- a/utils/packet_input.py
+++ b/utils/packet_input.py
@@ -85,7 +85,7 @@ class InputPacketInfo:
             if not cls._check_firewal_out_drop_rule():
                 raise FirewallException("Added DROP rule cannot be verified")
             return True
-        except subprocess.CalledProcessError:
+        except:
             raise FirewallException("Adding DROP rule failed")
 
     @classmethod
@@ -97,7 +97,7 @@ class InputPacketInfo:
                 raise FirewallException(
                     "Removing DROP rule cannot be verified")
             return True
-        except subprocess.CalledProcessError:
+        except:
             raise FirewallException("Removing DROP rule failed")
 
     @classmethod


### PR DESCRIPTION
There was a a problem on exception handling for `iptables` existence check routine which is fixed  
Also using `iptables` has been made optional as some systems may have other type of firewall  
Now only if user ask for auto config of `iptables` and it doesn't exist app crashes with error, otherwise it assumes user has no problem about auto RST response of linux  