### PR TITLE
feat: save dotfile if graphviz is available

### DIFF
--- a/utils/vis.py
+++ b/utils/vis.py
@@ -262,6 +262,11 @@ def save_measurement_graph(graph_name, attach_jscss):
         graph_name = graph_name[:-5]
     graph_path = graph_name + ".html"
     net_vis.save_graph(graph_path)
+    try:
+        import pygraphviz
+        nx.nx_agraph.write_dot(multi_directed_graph, graph_name + ".dot")
+    except ImportError:
+        pass
     print("saved: " + graph_path)
 
 


### PR DESCRIPTION
This tries to save a graphviz dotfile is the pygraphviz library is installed (optional)

As exporting a `dotfile` with `networkx` requires `pygraphviz` and it depends on `graphviz` and `graphviz-dev` libraries the commit only exports if the required libraries be installed on system, otherwise it does nothing